### PR TITLE
Fix deprecated name tmpDir -> tmpdir

### DIFF
--- a/request.js
+++ b/request.js
@@ -41,7 +41,7 @@ urllib.request(input.url, input.args, function (err, data, res) {
     type = 'string';
   }
 
-  var filepath = path.join(os.tmpDir(), name);
+  var filepath = path.join(os.tmpdir(), name);
 
   // if need to writeFile
   if ((res.statusCode / 100 | 0) === 2 && input.args.writeFile) {


### PR DESCRIPTION
This was deprecated in Node 7 and was removed in 14.

https://nodejs.org/api/deprecations.html#deprecations_dep0022_os_tmpdir